### PR TITLE
Fix delete TektonPipeline CR will delete crds and namespaces

### DIFF
--- a/pkg/reconciler/kubernetes/tektonpipeline/tektonpipeline.go
+++ b/pkg/reconciler/kubernetes/tektonpipeline/tektonpipeline.go
@@ -345,8 +345,8 @@ func (r *Reconciler) generateInstallerSet(ctx context.Context, tp *v1alpha1.Tekt
 	dis.AddReleaseVersionLabel(r.operatorVersion)
 
 	// Adds the ownerRef to the installer
-	ownerRef := *metav1.NewControllerRef(tp, tp.GetGroupVersionKind())
-	dis.AddOwnerReferences(ownerRef)
+	// ownerRef := *metav1.NewControllerRef(tp, tp.GetGroupVersionKind())
+	// dis.AddOwnerReferences(ownerRef)
 
 	// Adds the annotations to the installer
 	dis.AddAnnotationsKeyVal(v1alpha1.TargetNamespaceKey, tp.Spec.TargetNamespace)


### PR DESCRIPTION
Fix delete TektonPipeline CR will delete crds and namespaces of tekton pipelines

some related commit in upstream https://github.com/tektoncd/operator/commit/17f208754d4a9f0ea4958a8aa9e9d03ab5a99362

Signed-off-by: jtcheng <jtcheng@alauda.io>

# Changes

remove deleting logic that delete TektonPipeline CR will delete crds and namespaces of tekton pipelines

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes


```release-note
Fix: remove deleting logic that delete TektonPipeline CR will delete crds and namespaces of tekton pipelines
```

-->
