### PR TITLE
change default EnableApiFields to alpha

### DIFF
--- a/pkg/apis/operator/v1alpha1/tektonpipeline_defaults.go
+++ b/pkg/apis/operator/v1alpha1/tektonpipeline_defaults.go
@@ -59,7 +59,9 @@ func (p *PipelineProperties) setDefaults() {
 		p.EnableCustomTasks = ptr.Bool(false)
 	}
 	if p.EnableApiFields == "" {
-		p.EnableApiFields = ApiFieldStable
+		// we change default EnableApiFields to alpha,
+		// avoid upgrade from old version that cannot change to alpha
+		p.EnableApiFields = ApiFieldAlpha
 	}
 	if p.ScopeWhenExpressionsToTask == nil {
 		p.ScopeWhenExpressionsToTask = ptr.Bool(false)


### PR DESCRIPTION
Signed-off-by: jtcheng <jtcheng@alauda.io>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

change default EnableApiFields to alpha

we could change the value from configuration of TektonPipeline,  but it wont work when user upgrade from old TektonPipeline, tekton will set the default value when user  does not set enable-api-fields. 


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```release-note
configuration: change EnableApiFields to alpha
```

