### PR TITLE
 change api fields to alpha for old tektonpipeline resource upgrade

### DIFF
--- a/pkg/apis/operator/v1alpha1/tektonpipeline_defaults.go
+++ b/pkg/apis/operator/v1alpha1/tektonpipeline_defaults.go
@@ -27,10 +27,31 @@ const (
 	DefaultMetricsTaskrunLevel           = "task"
 	DefaultMetricsPipelierunDurationType = "histogram"
 	DefaultMetricsTaskrunDurationType    = "histogram"
+	KatanomiMigratePipelineApiFields     = "katanomi.dev/enable-api-fields-migrate"
 )
 
 func (tp *TektonPipeline) SetDefaults(ctx context.Context) {
 	tp.Spec.PipelineProperties.setDefaults()
+	tp.EnableApiFields(ctx)
+}
+
+func (tp *TektonPipeline) EnableApiFields(ctx context.Context) {
+	// as default, enable-api-fields would be alpha
+	if tp.Spec.EnableApiFields == "" {
+		tp.Spec.EnableApiFields = ApiFieldAlpha
+	}
+
+	// for old tektonpipeline resource, we will force change enable-api-fields to alpha
+	if tp.Annotations == nil {
+		tp.Annotations = map[string]string{}
+	}
+	if _, ok := tp.Annotations[KatanomiMigratePipelineApiFields]; !ok {
+		// we change EnableApiFields to alpha,
+		// avoid upgrade from old version that cannot change to alpha from stable
+		tp.Spec.PipelineProperties.EnableApiFields = ApiFieldAlpha
+		tp.Annotations[KatanomiMigratePipelineApiFields] = "true"
+	}
+
 }
 
 func (p *PipelineProperties) setDefaults() {
@@ -58,11 +79,7 @@ func (p *PipelineProperties) setDefaults() {
 	if p.EnableCustomTasks == nil {
 		p.EnableCustomTasks = ptr.Bool(false)
 	}
-	if p.EnableApiFields == "" {
-		// we change default EnableApiFields to alpha,
-		// avoid upgrade from old version that cannot change to alpha
-		p.EnableApiFields = ApiFieldAlpha
-	}
+
 	if p.ScopeWhenExpressionsToTask == nil {
 		p.ScopeWhenExpressionsToTask = ptr.Bool(false)
 	}

--- a/pkg/apis/operator/v1alpha1/tektonpipeline_defaults_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonpipeline_defaults_test.go
@@ -48,7 +48,7 @@ func Test_SetDefaults_PipelineProperties(t *testing.T) {
 		RequireGitSshSecretKnownHosts:            ptr.Bool(false),
 		EnableTektonOciBundles:                   ptr.Bool(false),
 		EnableCustomTasks:                        ptr.Bool(false),
-		EnableApiFields:                          ApiFieldStable,
+		EnableApiFields:                          ApiFieldAlpha,
 		ScopeWhenExpressionsToTask:               ptr.Bool(false),
 		PipelineMetricsProperties: PipelineMetricsProperties{
 			MetricsPipelinerunDurationType: DefaultMetricsPipelierunDurationType,
@@ -63,4 +63,14 @@ func Test_SetDefaults_PipelineProperties(t *testing.T) {
 	if d := cmp.Diff(properties, tp.Spec.PipelineProperties); d != "" {
 		t.Errorf("failed to update deployment %s", diff.PrintWantGot(d))
 	}
+
+	tp.Annotations[KatanomiMigratePipelineApiFields] = "true"
+	tp.Spec.PipelineProperties.EnableApiFields = ApiFieldStable
+	tp.SetDefaults(context.TODO())
+	properties.EnableApiFields = ApiFieldStable
+
+	if d := cmp.Diff(properties, tp.Spec.PipelineProperties); d != "" {
+		t.Errorf("failed to update deployment %s", diff.PrintWantGot(d))
+	}
+
 }


### PR DESCRIPTION

Signed-off-by: jtcheng <jtcheng@alauda.io>

# Changes

change api fields to alpha for old tektonpipeline resource upgrade

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
