### PR TITLE
cherry-pick: pullrequest #21 change enable-api-fields to alpha

### DIFF
--- a/pkg/apis/operator/v1alpha1/tektonpipeline_defaults_test.go
+++ b/pkg/apis/operator/v1alpha1/tektonpipeline_defaults_test.go
@@ -47,7 +47,7 @@ func Test_SetDefaults_PipelineProperties(t *testing.T) {
 		RequireGitSshSecretKnownHosts:            ptr.Bool(false),
 		EnableTektonOciBundles:                   ptr.Bool(false),
 		EnableCustomTasks:                        ptr.Bool(false),
-		EnableApiFields:                          "stable",
+		EnableApiFields:                          "alpha",
 		EmbeddedStatus:                           "full",
 		ScopeWhenExpressionsToTask:               nil,
 		SendCloudEventsForRuns:                   ptr.Bool(false),
@@ -60,6 +60,15 @@ func Test_SetDefaults_PipelineProperties(t *testing.T) {
 	}
 
 	tp.SetDefaults(context.TODO())
+
+	if d := cmp.Diff(properties, tp.Spec.PipelineProperties); d != "" {
+		t.Errorf("failed to update deployment %s", diff.PrintWantGot(d))
+	}
+
+	tp.Annotations[KatanomiMigratePipelineApiFields] = "true"
+	tp.Spec.PipelineProperties.EnableApiFields = "stable"
+	tp.SetDefaults(context.TODO())
+	properties.EnableApiFields = "stable"
 
 	if d := cmp.Diff(properties, tp.Spec.PipelineProperties); d != "" {
 		t.Errorf("failed to update deployment %s", diff.PrintWantGot(d))


### PR DESCRIPTION
Signed-off-by: jtcheng <jtcheng@alauda.io>

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

cherry-pick #21
change api fields to alpha for old tektonpipeline resource upgrade

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Run `make test lint` before submitting a PR
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
